### PR TITLE
Fix phpunit warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 composer.phar
 composer.lock
 composer-test.lock
+phpunit.xml
 vendor/
 build/artifacts/
 artifacts/

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,8 +8,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false">
+         stopOnFailure="false">
 
     <testsuites>
         <testsuite name="Inspector Laravel Test Suite">


### PR DESCRIPTION
The attribute "syntaxCheck" is not allowed, so I just help to remove it. Anyway, `phpunit.xml.dist` should be used as the skeleton instead of `phpunit.xml`
```
PHPUnit 8.2.4 by Sebastian Bergmann and contributors.

  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 12:
  - Element 'phpunit', attribute 'syntaxCheck': The attribute 'syntaxCheck' is not allowed.

  Test results may not be as expected.
```
