### PR TITLE
Fix ignored commands condition

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
         "php": ">=7.0.0",
+        "illuminate/console": "^5.1",
         "illuminate/contracts": "^5.1",
         "illuminate/support": "^5.1",
         "inspector-apm/inspector-php": "^2.0"

--- a/src/InspectorServiceProvider.php
+++ b/src/InspectorServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace Inspector\Laravel;
 
-
 use Illuminate\Contracts\Container\Container;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Foundation\Application as LaravelApplication;
@@ -13,6 +12,7 @@ use Inspector\Laravel\Providers\JobServiceProvider;
 use Inspector\Laravel\Providers\UnhandledExceptionServiceProvider;
 use Laravel\Lumen\Application as LumenApplication;
 use Inspector\Configuration;
+use Symfony\Component\Console\Input\ArgvInput;
 
 class InspectorServiceProvider extends ServiceProvider
 {
@@ -87,6 +87,8 @@ class InspectorServiceProvider extends ServiceProvider
      */
     protected function runningApprovedArtisanCommand(): bool
     {
-        return in_array($_SERVER['argv'][1] ?? null, config('inspector.ignore_commands'));
+        $input = new ArgvInput();
+
+        return ! in_array($input->getFirstArgument(), config('inspector.ignore_commands'));
     }
 }


### PR DESCRIPTION
* Firstly, **runningApprovedArtisanCommand** returns true if the current executing command isn't listed in config('inspector.ignore_commands'). So the condition must be.

```php
return ! in_array($commad, config('inspector.ignore_commands'));
```

* Secondly, getting command from $_SERVER['argv'][1] isn't always true because, Laravel artisan (is originally Symfony console) allows this syntax.

```bash
php artisan --daemon queue:work # $_SERVER['argv'][1] === "--daemon", not "queue:forget" while this command should be ignored.
```