### PR TITLE
Add possibility to ignore request made by user-agents

### DIFF
--- a/config/inspector.php
+++ b/config/inspector.php
@@ -174,4 +174,15 @@ return [
         'vendor/horizon*',
         'nova*'
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | User agents to ignore
+    |--------------------------------------------------------------------------
+    |
+    | Add at this list the user agents which requests you don't want monitoring
+    | in your Inspector dashboard.
+    |
+    */
+    'ignore_user_agents' => [],
 ];

--- a/src/Filters.php
+++ b/src/Filters.php
@@ -16,10 +16,16 @@ class Filters
      * @param Request $request
      * @return bool
      */
-    public static function isApprovedRequest(array $notAllowedPatterns, Request $request): bool
+    public static function isApprovedRequest(array $notAllowedPatterns, array $notAllowedUserAgents, Request $request): bool
     {
         foreach ($notAllowedPatterns as $pattern) {
             if ($request->is($pattern)) {
+                return false;
+            }
+        }
+
+        foreach ($notAllowedUserAgents as $userAgent) {
+            if ($request->userAgent() === $userAgent) {
                 return false;
             }
         }

--- a/src/Middleware/WebRequestMonitoring.php
+++ b/src/Middleware/WebRequestMonitoring.php
@@ -40,7 +40,11 @@ class WebRequestMonitoring implements TerminableInterface
      */
     protected function shouldRecorded($request): bool
     {
-        return config('inspector.enable') && Filters::isApprovedRequest(config('inspector.ignore_url'), $request);
+        return config('inspector.enable') && Filters::isApprovedRequest(
+            config('inspector.ignore_url'),
+            config('inspector.ignore_user_agents'),
+            $request
+        );
     }
 
     /**


### PR DESCRIPTION
I'm using Inspector for around 2-3 days, and I already generate ~40% of a daily events quota, only by requests from [updown.io](https://updown.io). So I made this little change, to have a posibility, to ignore requests made by `updown.io daemon 2.2`. 