### PR TITLE
fix missing phpdoc signature method

### DIFF
--- a/src/Facades/Inspector.php
+++ b/src/Facades/Inspector.php
@@ -21,7 +21,7 @@ use Inspector\Models\Transaction;
  * @method static mixed addSegment($callback, $type, $label = null, $throw = false)
  * @method static Error reportException(\Throwable $exception, $handled = true)
  * @method static void flush()
- * @method static void beforeFlush()
+ * @method static void beforeFlush(callable $callback)
  */
 class Inspector extends Facade
 {


### PR DESCRIPTION
Hello, Valerio. There is only missing signature of method beforeFlush in phpdoc from facade.

Orginal method:

![image](https://user-images.githubusercontent.com/7047662/163557772-448b67f1-5e2a-4f16-b786-92df0345af27.png)

But in the facade `callable $callback` is missing and using will be highlighted by ide:

![image](https://user-images.githubusercontent.com/7047662/163558163-db2558ed-de05-47a2-87a7-4ca889221eff.png)

