### PR TITLE
add default value

### DIFF
--- a/src/InspectorServiceProvider.php
+++ b/src/InspectorServiceProvider.php
@@ -79,9 +79,8 @@ class InspectorServiceProvider extends ServiceProvider
                 ->setVersion(self::VERSION)
                 ->setTransport(config('inspector.transport', 'async'))
                 ->setOptions(config('inspector.options', []))
-                ->setMaxItems(config('inspector.max_items', 100))
-                ->serverSamplingRatio(config('inspector.server_sampling_ratio'));
-
+                ->setMaxItems(config('inspector.max_items', 100));
+            
             return new Inspector($configuration);
         });
 

--- a/src/InspectorServiceProvider.php
+++ b/src/InspectorServiceProvider.php
@@ -75,11 +75,11 @@ class InspectorServiceProvider extends ServiceProvider
         $this->app->singleton('inspector', function ($app) {
             $configuration = (new Configuration(config('inspector.key')))
                 ->setEnabled(config('inspector.enable', true))
-                ->setUrl(config('inspector.url'))
+                ->setUrl(config('inspector.url', 'https://ingest.inspector.dev'))
                 ->setVersion(self::VERSION)
-                ->setTransport(config('inspector.transport'))
-                ->setOptions(config('inspector.options'))
-                ->setMaxItems(config('inspector.max_items'))
+                ->setTransport(config('inspector.transport', 'async'))
+                ->setOptions(config('inspector.options', []))
+                ->setMaxItems(config('inspector.max_items', 100))
                 ->serverSamplingRatio(config('inspector.server_sampling_ratio'));
 
             return new Inspector($configuration);

--- a/src/InspectorServiceProvider.php
+++ b/src/InspectorServiceProvider.php
@@ -74,7 +74,7 @@ class InspectorServiceProvider extends ServiceProvider
         // Bind Inspector service class
         $this->app->singleton('inspector', function ($app) {
             $configuration = (new Configuration(config('inspector.key')))
-                ->setEnabled(config('inspector.enable'))
+                ->setEnabled(config('inspector.enable', true))
                 ->setUrl(config('inspector.url'))
                 ->setVersion(self::VERSION)
                 ->setTransport(config('inspector.transport'))


### PR DESCRIPTION
referencing #11 

I'm 99% sure that this will prevent any issues during deployment/installation and only mirrors the default config file rather than passing `null`