### PR TITLE
disable monitoring in unit tests

### DIFF
--- a/src/Middleware/WebRequestMonitoring.php
+++ b/src/Middleware/WebRequestMonitoring.php
@@ -5,6 +5,7 @@ namespace Inspector\Laravel\Middleware;
 
 
 use Closure;
+use Illuminate\Support\Facades\App;
 use Inspector\Laravel\Facades\Inspector;
 use Illuminate\Support\Facades\Auth;
 use Inspector\Laravel\Filters;
@@ -23,6 +24,8 @@ class WebRequestMonitoring implements TerminableInterface
     public function handle($request, Closure $next)
     {
         if (
+            !App::runningUnitTests()
+            &&
             Inspector::needTransaction()
             &&
             Filters::isApprovedRequest(config('inspector.ignore_url'), $request)


### PR DESCRIPTION
Hello, Valerio!

I think the monitoring should be disabled when unit tests are running in the application. Cause it throws the exception: 
ErrorException: `Undefined index: REQUEST_URI in file /vendor/inspector-apm/inspector-laravel/src/Middleware/WebRequestMonitoring.php on line 102`

Sample of the test:

```
public function test_home_page_login_redirect()
	{
		$mainRoute = route('site.main');
		$loginRoute = route('user.login');
		$response = $this->get($mainRoute);
		$response->assertRedirect($loginRoute);
	}
```