### PR TITLE
Laravel Octane support by using `Illuminate\Http\Request`

### DIFF
--- a/src/Inspector.php
+++ b/src/Inspector.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Inspector\Laravel;
+use Inspector\Laravel\Models\Transaction;
 
 class Inspector extends \Inspector\Inspector
 {
@@ -27,5 +28,21 @@ class Inspector extends \Inspector\Inspector
 
             return app()->call($callback, $parameters);
         }, 'method', $label, true);
+    }
+
+    /**
+     * Create and start new Transaction.
+     *
+     * @param string $name
+     * @return Transaction
+     * @throws \Exception
+     */
+    public function startTransaction($name)
+    {
+        $this->transaction = new Transaction($name);
+        $this->transaction->start();
+
+        $this->addEntries($this->transaction);
+        return $this->transaction;
     }
 }

--- a/src/Middleware/WebRequestMonitoring.php
+++ b/src/Middleware/WebRequestMonitoring.php
@@ -88,6 +88,9 @@ class WebRequestMonitoring implements TerminableInterface
                 ->addContext('Response Body', json_decode($response->getContent(), true))
                 ->setResult($response->getStatusCode());
         }
+        if (isset($_SERVER['LARAVEL_OCTANE'])) {
+            Inspector::flush();
+        }
     }
 
     /**

--- a/src/Models/Partials/Http.php
+++ b/src/Models/Partials/Http.php
@@ -1,0 +1,17 @@
+<?php
+
+
+namespace Inspector\Laravel\Models\Partials;
+
+
+class Http extends \Inspector\Models\Partials\Http
+{
+    /**
+     * Http constructor.
+     */
+    public function __construct()
+    {
+        $this->request = new Request();
+        $this->url = new Url();
+    }
+}

--- a/src/Models/Partials/Request.php
+++ b/src/Models/Partials/Request.php
@@ -11,7 +11,7 @@ class Request extends \Inspector\Models\Partials\Request
      */
     public function __construct()
     {
-        $request = request();
+        $request = \request();
         $this->method = $request->getMethod();
 
         $this->version = $request->getProtocolVersion()

--- a/src/Models/Partials/Request.php
+++ b/src/Models/Partials/Request.php
@@ -1,0 +1,34 @@
+<?php
+
+
+namespace Inspector\Laravel\Models\Partials;
+
+
+class Request extends \Inspector\Models\Partials\Request
+{
+    /**
+     * Request constructor.
+     */
+    public function __construct()
+    {
+        $request = request();
+        $this->method = $request->getMethod();
+
+        $this->version = $request->getProtocolVersion()
+            ? \substr($request->getProtocolVersion(), \strpos($request->getProtocolVersion(), '/'))
+            : 'unknown';
+
+        $this->socket = new Socket();
+
+        $this->cookies = $request->cookie();
+
+        $h = $request->header();
+        if (\array_key_exists('sec-ch-ua', $h)) {
+            unset($h['sec-ch-ua']);
+        }
+        if (\array_key_exists('cookie', $h)) {
+            unset($h['cookie']);
+        }
+        $this->headers = $h;
+    }
+}

--- a/src/Models/Partials/Socket.php
+++ b/src/Models/Partials/Socket.php
@@ -11,7 +11,7 @@ class Socket extends \Inspector\Models\Partials\Socket
      */
     public function __construct()
     {
-        $request = request();
+        $request = \request();
         $this->remote_address = $request->getClientIp() ?? '';
         $this->encrypted = $request->isSecure();
     }

--- a/src/Models/Partials/Socket.php
+++ b/src/Models/Partials/Socket.php
@@ -1,0 +1,18 @@
+<?php
+
+
+namespace Inspector\Laravel\Models\Partials;
+
+
+class Socket extends \Inspector\Models\Partials\Socket
+{
+    /**
+     * Socket constructor.
+     */
+    public function __construct()
+    {
+        $request = request();
+        $this->remote_address = $request->getClientIp() ?? '';
+        $this->encrypted = $request->isSecure();
+    }
+}

--- a/src/Models/Partials/Url.php
+++ b/src/Models/Partials/Url.php
@@ -1,0 +1,21 @@
+<?php
+
+
+namespace Inspector\Laravel\Models\Partials;
+
+
+class Url extends \Inspector\Models\Partials\Url
+{
+    /**
+     * Url constructor.
+     */
+    public function __construct()
+    {
+        $request = request();
+        $this->protocol = $request->getScheme();
+        $this->port = $request->getPort() ?? '';
+        $this->path = $request->getScriptName() ?? '';
+        $this->search = '?' . (($request->getQueryString() ?? '') ?? '');
+        $this->full = $request->getUri() ? $request->getUri() : '';
+    }
+}

--- a/src/Models/Partials/Url.php
+++ b/src/Models/Partials/Url.php
@@ -11,7 +11,7 @@ class Url extends \Inspector\Models\Partials\Url
      */
     public function __construct()
     {
-        $request = request();
+        $request = \request();
         $this->protocol = $request->getScheme();
         $this->port = $request->getPort() ?? '';
         $this->path = $request->getScriptName() ?? '';

--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -1,0 +1,26 @@
+<?php
+
+
+namespace Inspector\Laravel\Models;
+
+
+use Exception;
+use Inspector\Exceptions\InspectorException;
+use Inspector\Models\Partials\Host;
+use Inspector\Laravel\Models\Partials\Http;
+use Inspector\Models\Partials\User;
+
+class Transaction extends \Inspector\Models\Transaction
+{
+    /**
+     * Mark the current transaction as an HTTP request.
+     *
+     * @return $this
+     */
+    public function markAsRequest()
+    {
+        $this->setType('request');
+        $this->http = new Http();
+        return $this;
+    }
+}


### PR DESCRIPTION
This PR will change `inspector-laravel` to use `Illuminate\Http\Request` instead of  `$_SERVER` from `inspector-php`.
The current solution from https://github.com/inspector-apm/inspector-laravel/issues/45#issuecomment-2225460697 was by adding missing keys to `$_SERVER` does prevent errors from application but doesn't record some information eg. `$_COOKIE` and `apache_request_headers` when Laravel Octane is enabled (Maybe due to long-running process doesn't like working with global variables?).

Note:
I also added Laravel Octane detection for `WebRequestMonitoring` middleware.